### PR TITLE
make it compile with a modern compiler. fix warnings.

### DIFF
--- a/cramfsck.c
+++ b/cramfsck.c
@@ -669,6 +669,7 @@ int main(int argc, char **argv)
 		switch (c) {
 		case 'h':
 			usage(FSCK_OK);
+			break;  /* usage() calls exit(), but add break to silence warning */
 		case 'x':
 #ifdef INCLUDE_FS_TESTS
 			opt_extract = 1;


### PR DESCRIPTION
```
$ make --version
GNU Make 4.4.1
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

$ gcc --version
gcc (Debian 14.2.0-19) 14.2.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ make
gcc -W -Wall -O2 -g -I.   mkcramfs.c  -lz -o mkcramfs
gcc -W -Wall -O2 -g -I.   cramfsck.c  -lz -o cramfsck

$ ./mkcramfs -h
usage: mkcramfs [-h] [-e edition] [-i file] [-n name] dirname outfile
 -h         print this help
 -E         make all warnings errors (non-zero exit status)
 -e edition set edition number (part of fsid)
 -i file    insert a file image into the filesystem (requires >= 2.4.0)
 -n name    set name of cramfs filesystem
 -p         pad by 512 bytes for boot code
 -s         sort directory entries (old option, ignored)
 -v         be more verbose
 -z         make explicit holes (requires >= 2.3.39)
 dirname    root of the directory tree to be compressed
 outfile    output file

$ ./cramfsck -h
usage: cramfsck [-hv] [-x dir] file
 -h         print this help
 -x dir     extract into dir
 -v         be more verbose
 file       file to test
```